### PR TITLE
Add TypeScript as devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "src/main.js",
   "scripts": {
     "clean:ts": "rm src/**/*.js; rm src/*.js; rm environment/*.js",
-    "build": "tsc",
+    "build": "yarn tsc",
     "dist": "yarn build && electron-builder",
     "pack": "electron-builder --dir",
     "postinstall": "electron-builder install-app-deps",
@@ -23,7 +23,8 @@
     "@types/electron-devtools-installer": "^2.2.0",
     "electron": "^8.2.3",
     "electron-builder": "^22.4.1",
-    "electron-devtools-installer": "^3.1.0"
+    "electron-devtools-installer": "^3.1.0",
+    "typescript": "^3.9.7"
   },
   "dependencies": {
     "electron-log": "^4.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1940,6 +1940,11 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
+typescript@^3.9.7:
+  version "3.9.7"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
+  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
+
 unique-string@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/unique-string/-/unique-string-2.0.0.tgz#39c6451f81afb2749de2b233e3f7c5e8843bd89d"


### PR DESCRIPTION
Previously, it was expected that TypeScript was installed globally on the system. Also enforces versions of compatible TypeScript.